### PR TITLE
Update MyPackageInfo.java

### DIFF
--- a/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/MyPackageInfo.java
+++ b/ActivityLauncherApp/src/main/java/de/szalkowski/activitylauncher/MyPackageInfo.java
@@ -20,14 +20,23 @@ public class MyPackageInfo implements Comparable<MyPackageInfo> {
     protected String name;
     protected MyActivityInfo[] activities;
 
-    public static MyPackageInfo fromPackageInfo(PackageManagerCache cache, PackageInfo info, Configuration config) throws PackageManager.NameNotFoundException {
+    public static MyPackageInfo fromPackageInfo(PackageManagerCache cache, PackageInfo info, Configuration config)  {
         var pm = cache.getPackageManager();
         var myInfo = new MyPackageInfo();
         myInfo.package_name = info.packageName;
         ApplicationInfo app = info.applicationInfo;
 
         if (app != null) {
-            myInfo.name = getLocalizedName(config, pm, myInfo, app);
+            try {
+                myInfo.name = getLocalizedName(config, pm, myInfo, app);
+            } catch (PackageManager.NameNotFoundException | RuntimeException ignored) {
+
+            }
+            if(myInfo.name==null){
+                //a way to get name of app if it is null (it will also fail to get on getLocalizedName)
+
+                myInfo.name=info.applicationInfo.loadLabel(pm).toString();
+            }
             try {
                 myInfo.icon = pm.getApplicationIcon(app);
             } catch (Exception e) {


### PR DESCRIPTION
All apps and activities are now loaded on resolve, but formerly excluded app names are not localized!

-The the formerly excluded apps, with their activities are all not able to go through getLocalizedName(config, pm, myInfo, app); the Runtime Exception is ignored.

The names are derived from ApplicationInfo.loadLabel(packageManager).toString(); MyPackageInfo.java